### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <qooxdoo.build.python>${python.exec}</qooxdoo.build.python>
         <jackson.version>2.5.3</jackson.version>
         <resteasy.version>3.0.11.Final</resteasy.version>
-        <commons.collection.version>3.2.1</commons.collection.version>
+        <commons.collection.version>3.2.2</commons.collection.version>
         <commons.validator.version>1.4.0</commons.validator.version>
         <httpcomponents.version>4.5</httpcomponents.version>
         <tomcat.version>7.0.62</tomcat.version>


### PR DESCRIPTION

Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/